### PR TITLE
design fix

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -111,7 +111,7 @@ body{
 }
 
 #filter p, #filter2 p{
-  font-size: 2vw;
+  font-size: 1.8vw;
   margin: 0 0.2vw 0 0.6vw;
 }
 
@@ -182,13 +182,13 @@ body{
 
 .contents h2{
   font-family: "GENJ-Heavy";
-  font-size: 3vw;
+  font-size: 28px;
   margin-bottom: 2vh;
 }
 
 .contents p{
   font-family: 'GENJ-Light';
-  font-size: 1.2vw;
+  font-size: 14px;
 }
 
 #cards, #cards2 {
@@ -196,12 +196,13 @@ body{
   display: flex;
   flex-wrap: wrap;
   align-content: space-around;
+  margin-left: -16px;
 }
 
 .card{
   margin: 20px;
-  height: 25vh;
-  width: 280px;
+  height: 200px;
+  width: 240px;
   box-shadow: 1px 1px 2px #999;
   border: solid 0.5px lightgray;
   padding: 3vh 2vw;
@@ -220,7 +221,7 @@ body{
 .card-title{
   display: block;
   font-family: "GENJ-Heavy";
-  font-size:  1.3vw;
+  font-size:  14px;
   height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -230,9 +231,12 @@ body{
 
 .card-detail{
   font-family: "GENJ-Light";
-  font-size:  1.1vw;
   position: absolute;
   bottom: 3vh;
+}
+
+.card-detail .card-ministry, .card-detail .card-pdate{
+  font-size:  14px;
 }
 
 #header{
@@ -281,7 +285,7 @@ body{
 
 #submit, #submit2{
   font-size: 2.5vw;
-  color: #4285f4;
+  color: #747474;
   font-size: 2.5vw;
   width: 8vw;
   padding-left: 16px;
@@ -293,10 +297,6 @@ body{
 .results{
   position: relative;
   padding-top: 16vh;
-}
-
-.result{
-  margin-bottom: 3vh;
 }
 
 .pagination-wrapper {
@@ -405,15 +405,13 @@ select.ym-select:first-child {
 
   #cards, #cards2{
     flex-direction: column;
+    margin-left: 0;
+    margin-top: 30px;
   }
 
   .card{
     width: 70vw;
     margin: 0 auto 30px;
-  }
-
-  .card-title{
-    font-size: 5.0vw;
   }
 
   #filter p, #filter2 p{


### PR DESCRIPTION
# 修正内容
- 検索件数や報告書タイトルなど大きすぎるフォントサイズを調整しました。
- カードの大きさを調整し、PCフルスクリーン時に4枚が横に並ぶようにしました。
- カードと検索条件欄の左端を揃えました。
- 余白を調整しました。
- 検索アイコンの色をグレーにしました。

# スクショ
![0030-11-23 2 23 28](https://user-images.githubusercontent.com/17106564/48916992-ff10e500-eec7-11e8-8cd5-ac62589b4c99.png)
